### PR TITLE
Use Weather API's icons instead of my own for the `#forecast` section of the page

### DIFF
--- a/src/components/forecast/displayForecast.js
+++ b/src/components/forecast/displayForecast.js
@@ -15,6 +15,9 @@ const displayForecast = (forecastArr) => {
     weatherTextElement.textContent = day.day.condition.text;
 
     const weatherFigureElement = currentCard.querySelector(".icon");
+    const imgElement = new Image();
+    imgElement.src = day.day.condition.icon;
+    weatherFigureElement.appendChild(imgElement);
 
     const maxTempElement = currentCard.querySelector(".max-temp");
     const maxTemp = day.day.maxtemp_c.toFixed(0);

--- a/src/components/forecast/displayForecast.js
+++ b/src/components/forecast/displayForecast.js
@@ -14,7 +14,7 @@ const displayForecast = (forecastArr) => {
     const weatherTextElement = currentCard.querySelector(".weather");
     weatherTextElement.textContent = day.day.condition.text;
 
-    // todo: icon for weather condition (start with using the api's i think)
+    const weatherFigureElement = currentCard.querySelector(".icon");
 
     const maxTempElement = currentCard.querySelector(".max-temp");
     const maxTemp = day.day.maxtemp_c.toFixed(0);

--- a/src/components/forecast/index.css
+++ b/src/components/forecast/index.css
@@ -51,23 +51,3 @@
   font-size: 0.6rem;
   opacity: 0.7;
 }
-
-.card .icon {
-  width: 50px;
-  height: 50px;
-}
-
-/* .card .icon.sunny {
-  mask-image: url("../../assets/icons/sun-filled.svg");
-  background-color: var(--light-orange-clr);
-}
-
-.card .icon.cloudy {
-  mask-image: url("../../assets/icons/cloud.svg");
-  background-color: lightgray;
-}
-
-.card .icon.rain {
-  mask-image: url("../../assets/icons/rain-svgrepo-com.svg");
-  background-color: lightgray;
-} */

--- a/src/components/forecast/index.css
+++ b/src/components/forecast/index.css
@@ -57,7 +57,7 @@
   height: 50px;
 }
 
-.card .icon.sunny {
+/* .card .icon.sunny {
   mask-image: url("../../assets/icons/sun-filled.svg");
   background-color: var(--light-orange-clr);
 }
@@ -70,4 +70,4 @@
 .card .icon.rain {
   mask-image: url("../../assets/icons/rain-svgrepo-com.svg");
   background-color: lightgray;
-}
+} */

--- a/src/index.html
+++ b/src/index.html
@@ -59,7 +59,7 @@
           <div class="inner">
             <p class="day">Today</p>
             <p class="weather">Clear</p>
-            <figure class="icon sunny"></figure>
+            <figure class="icon"></figure>
             <p class="temperature">
               <span class="max-temp">19°</span><span class="min-temp">/7°</span>
             </p>
@@ -74,7 +74,7 @@
           <div class="inner">
             <p class="day">Tomorrow</p>
             <p class="weather">Sunny</p>
-            <figure class="icon sunny"></figure>
+            <figure class="icon"></figure>
             <p class="temperature">
               <span class="max-temp">19°</span><span class="min-temp">/7°</span>
             </p>
@@ -89,7 +89,7 @@
           <div class="inner">
             <p class="day">Friday</p>
             <p class="weather">Showers</p>
-            <figure class="icon rain"></figure>
+            <figure class="icon"></figure>
             <p class="temperature">
               <span class="max-temp">19°</span><span class="min-temp">/7°</span>
             </p>


### PR DESCRIPTION
This is because there are many many possibilities of potential weather conditions from the API (see screenshot of the CSV file that shows these:)
![image](https://github.com/henrylin03/whats-the-weather/assets/83106787/212b2838-06b6-46e8-910b-119e6cc46529)

we can use our own SVG icons once we map everything in #20, though this is not a priority for MVP