### PR TITLE
use weather api's icon instead of my own for the `#today-details` section of the page

### DIFF
--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -13,6 +13,10 @@ const windSpeedElement = document.querySelector(
 const updatedTimeElement = document.querySelector(".last-updated-time");
 
 const display = (weatherObj) => {
+  const weatherIconImg = new Image();
+  weatherIconImg.src = weatherObj.current.condition.icon;
+  weatherIconElement.appendChild(weatherIconImg);
+
   const currentTempCelsius = weatherObj.current.temp_c.toFixed(0);
   currentTemperatureElement.textContent = `${currentTempCelsius}°`;
 

--- a/src/components/todayDetails/index.css
+++ b/src/components/todayDetails/index.css
@@ -29,9 +29,6 @@
 #today-details .weather .icon {
   width: 150px;
   height: 150px;
-  background-color: white;
-  mask-image: url("../../assets/icons/sun-filled.svg");
-  mask-repeat: no-repeat;
 }
 
 #today-details .temperature-text {

--- a/src/components/todayDetails/index.css
+++ b/src/components/todayDetails/index.css
@@ -26,11 +26,6 @@
   gap: 5px;
 }
 
-#today-details .weather .icon {
-  width: 150px;
-  height: 150px;
-}
-
 #today-details .temperature-text {
   font-size: 7.5rem;
 }


### PR DESCRIPTION
same as #22, which was for the `#forecast` section of the page. the current PR is for the `#today-details` section of the page.

we can use our own SVG icons once we map everything in https://github.com/henrylin03/whats-the-weather/issues/20, though this is not a priority for MVP