### PR TITLE
fix: incorrect timezone shown for last updated time

### DIFF
--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -26,13 +26,14 @@ const display = (weatherObj) => {
   windSpeedElement.textContent = `${windSpeed}km/h`;
 
   const lastUpdatedDateTime = weatherObj.current.last_updated;
-  updatedTimeElement.textContent = `${getLastUpdatedTime(lastUpdatedDateTime)} local time`;
+  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedDateTime);
 };
 
 const getLastUpdatedTime = (lastUpdatedStr) =>
   new Date(lastUpdatedStr).toLocaleTimeString(navigator.language, {
     hour: "numeric",
     minute: "2-digit",
+    timeZoneName: "short",
   });
 
 export default display;

--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -25,12 +25,12 @@ const display = (weatherObj) => {
   const windSpeed = weatherObj.current.wind_kph.toFixed(0);
   windSpeedElement.textContent = `${windSpeed}km/h`;
 
-  const lastUpdatedDateTime = weatherObj.current.last_updated;
-  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedDateTime);
+  const lastUpdatedUnixTime = weatherObj.current.last_updated_epoch;
+  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedUnixTime);
 };
 
-const getLastUpdatedTime = (lastUpdatedStr) =>
-  new Date(lastUpdatedStr).toLocaleTimeString(navigator.language, {
+const getLastUpdatedTime = (unixTime) =>
+  new Date(unixTime * 1000).toLocaleTimeString(navigator.language, {
     hour: "numeric",
     minute: "2-digit",
     timeZoneName: "short",

--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -28,13 +28,14 @@ const display = (weatherObj) => {
   windSpeedElement.textContent = `${windSpeed}km/h`;
 
   const lastUpdatedDateTime = weatherObj.current.last_updated;
-  updatedTimeElement.textContent = `${getLastUpdatedTime(lastUpdatedDateTime)} local time`;
+  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedDateTime);
 };
 
 const getLastUpdatedTime = (lastUpdatedStr) =>
   new Date(lastUpdatedStr).toLocaleTimeString(navigator.language, {
     hour: "numeric",
     minute: "2-digit",
+    timeZoneName: "short",
   });
 
 export default display;

--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -13,6 +13,8 @@ const windSpeedElement = document.querySelector(
 const updatedTimeElement = document.querySelector(".last-updated-time");
 
 const display = (weatherObj) => {
+  console.log(weatherObj);
+
   const weatherIconImg = new Image();
   weatherIconImg.src = weatherObj.current.condition.icon;
   weatherIconElement.appendChild(weatherIconImg);
@@ -27,12 +29,12 @@ const display = (weatherObj) => {
   const windSpeed = weatherObj.current.wind_kph.toFixed(0);
   windSpeedElement.textContent = `${windSpeed}km/h`;
 
-  const lastUpdatedDateTime = weatherObj.current.last_updated;
-  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedDateTime);
+  const lastUpdatedUnixTime = weatherObj.current.last_updated_epoch;
+  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedUnixTime);
 };
 
-const getLastUpdatedTime = (lastUpdatedStr) =>
-  new Date(lastUpdatedStr).toLocaleTimeString(navigator.language, {
+const getLastUpdatedTime = (unixTime) =>
+  new Date(unixTime * 1000).toLocaleTimeString(navigator.language, {
     hour: "numeric",
     minute: "2-digit",
     timeZoneName: "short",

--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -28,14 +28,13 @@ const display = (weatherObj) => {
   windSpeedElement.textContent = `${windSpeed}km/h`;
 
   const lastUpdatedDateTime = weatherObj.current.last_updated;
-  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedDateTime);
+  updatedTimeElement.textContent = `${getLastUpdatedTime(lastUpdatedDateTime)} local time`;
 };
 
 const getLastUpdatedTime = (lastUpdatedStr) =>
   new Date(lastUpdatedStr).toLocaleTimeString(navigator.language, {
     hour: "numeric",
     minute: "2-digit",
-    timeZoneName: "short",
   });
 
 export default display;

--- a/src/components/todayDetails/display.js
+++ b/src/components/todayDetails/display.js
@@ -26,14 +26,13 @@ const display = (weatherObj) => {
   windSpeedElement.textContent = `${windSpeed}km/h`;
 
   const lastUpdatedDateTime = weatherObj.current.last_updated;
-  updatedTimeElement.textContent = getLastUpdatedTime(lastUpdatedDateTime);
+  updatedTimeElement.textContent = `${getLastUpdatedTime(lastUpdatedDateTime)} local time`;
 };
 
 const getLastUpdatedTime = (lastUpdatedStr) =>
   new Date(lastUpdatedStr).toLocaleTimeString(navigator.language, {
     hour: "numeric",
     minute: "2-digit",
-    timeZoneName: "short",
   });
 
 export default display;


### PR DESCRIPTION
API provides the local time of wherever you're looking up, and not the local time of the browser

This PR opts to convert the 'last updated time' from UNIX time into the local browser's time and timezone

fixes #28 